### PR TITLE
Fix item index redirect

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -65,7 +65,7 @@
 
 // items styling
 
-.items {
+.items, .carts {
   table {
     border-collapse: collapse;
   }
@@ -112,6 +112,13 @@
     background: #f3fafe;
   }
 }
+
+.total_cost {
+  color: #244
+  
+}
+
+
 
 // style sidebar/nav
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user
+    session.clear if @user.nil?
     @user ||= User.find(session[:user_id]) if session[:user_id]
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,8 +10,10 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user
-    session.clear if @user.nil?
     @user ||= User.find(session[:user_id]) if session[:user_id]
+    rescue ActiveRecord::RecordNotFound
+      session.clear
+    return
   end
 
   def current_admin?

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -8,7 +8,7 @@ class CartsController < ApplicationController
     session[:cart] = @cart.contents
 
     flash[:notice] = "You now have #{pluralize(@cart.count_of(item.id), item.title)}."
-    redirect_to category_path(item.category)
+    redirect_to :back
   end
 
   def show

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -8,7 +8,7 @@ class CartsController < ApplicationController
     session[:cart] = @cart.contents
 
     flash[:notice] = "You now have #{pluralize(@cart.count_of(item.id), item.title)}."
-    redirect_to :back
+    redirect_back(fallback_location: items_path)
   end
 
   def show

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -25,7 +25,7 @@ class Cart
   end
 
   def items
-    contents.keys.map { |id| Item.find(id) }
+    Item.find([contents.keys])
   end
 
   def delete(key)

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -2,15 +2,50 @@
 <h1>Your cart!</h1> <br>
 <h3>You have <%= @cart.total_count %> illegal items in your cart</h3> <br>
 
-<% @cart_item.each do |item| %>
-  Title: <%= item.title %> <br>
-  Description: <%= item.description %> <br>
-  Unit Price: <%= item.format_price %> <br>
-  Total: <%= item.subtotal %> <br>
-  Quantity: <%= item.quantity %> <br>
-  <%= link_to "Remove Item", cart_path(item_id: item.id), method: :delete, class: "btn btn-danger" %> <br> <br>
-<% end %>
+<table>
+  <% @cart_item.each do |item| %>
+  <tr class="cycle('category_line_odd', 'category_line_even') %>">
+    <td>
+      <dl>
+        <dt> Title </dt>
+        <dd> <%= item.title %> </dd>
+      </dl>
+    </td>
+    <td>
+      <dl>
+        <dt> Description </dt>
+        <dd> <%= item.description %> </dd>
+      </dl>
+    </td>
+    <td>
+      <dl>
+        <dt> Quantity </dt>
+        <dd> <%= item.quantity %> </dd>
+      </dl>
+    </td>
+    <td>
 
-<h3>Total Cost: <%= @cart.total_cost %></h3>
+      <dl>
+        <dt> Unit Price </dt>
+        <dd> <%= item.format_price %> </dd>
+      </dl>
+    </td>
+    <td>
+      <dl>
+        <dt> Subtotal </dt>
+        <dd> <%= item.subtotal %> </dd>
+      </dl>
+    </td>
+
+    </td>
+    <td class="list_actions">
+
+    <%= link_to "Remove Item", cart_path(item_id: item.id), method: :delete, class: "btn btn-danger" %> <br> <br>
+  </td>
+  <% end %>
+  </tr>
+</table>
+
+<h3 class="total_cost">Total Cost: <%= @cart.total_cost %></h3>
 
 <%= checkout_cart_items %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,16 +1,15 @@
 <h1>Order History</h1>
 
-<h2>Total Orders: <%= @orders.count%></h2>
+<h3>Total Orders: <%= @orders.count%></h2>
 
-<% @orders.reverse.each do |order|%>
-<%= link_to "Order ID:", order_path(order)%> <%= order.id %> <br>
-  <% order.invoices.each do |invoice| %>
-    Title: <%= invoice.item.title %>  <br>
-    Quantity: <%= invoice.quantity %> <br>
-    Unit Cost: <%= invoice.item_cost %> <br>
-    Quantity Cost: <%= invoice.quantity_cost %><br>
-    Created at: <%= order.created_at.strftime("%Y %B %d") %>
-  <% end %>
-  <!-- <p><strong>Created On: <%#= order.created_at.strftime("%Y %B %d") %><strong></p> -->
-  <p><strong>Total Cost: <%= order.total_cost %><strong></p>
+<table>
+<% @orders.reverse.each.with_index do |order, index|%>
+  <%= link_to "Order #{index + 1}", order_path(order)%> <br>
+  Total cost: <%= order.total_cost %><br />
+  Created at: <%= order.created_at.strftime("%B %d, %Y" ) %><br />
+  Status: <%= order.status %>
+
+
+  <p><strong>Purchase history total cost: <%= order.total_cost %><strong></p>
 <% end %>
+</table>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -5,11 +5,8 @@
 <table>
 <% @orders.reverse.each.with_index do |order, index|%>
   <%= link_to "Order #{index + 1}", order_path(order)%> <br>
-  Total cost: <%= order.total_cost %><br />
-  Created at: <%= order.created_at.strftime("%B %d, %Y" ) %><br />
+  Created at: <%= order.created_at.strftime("%B %d, %Y") %><br />
   Status: <%= order.status %>
-
-
-  <p><strong>Purchase history total cost: <%= order.total_cost %><strong></p>
+  <p><strong>Purchase history total cost: <%= order.total_cost %></strong></p>
 <% end %>
 </table>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -16,4 +16,6 @@
   <%= @order.created_at.strftime("%l:%M %p") %><br />
 </table>
 
+Order total: <%= @order.total_cost %><br />
+
 <%= link_to "Back to all orders", orders_path %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,16 +1,30 @@
-<h3>Order placed on <%= @order.created_at.strftime("%Y %B %d") %></h3>
+<h3>Order placed on <%= @order.created_at.strftime("%B %d, %Y") %></h3>
 
 
 <table class="items">
   <% @order.invoices.each do |invoice| %>
-        <%= link_to invoice.item.title, item_path(invoice.item) %><br />
-        Quantity:
-        <%= invoice.quantity %><br />
-        Unit Price:
-        <%= invoice.item_cost %><br />
-        Sub-total:
-        <%= invoice.quantity_cost %><br />
+  <tr class ="<%= cycle('category_line_odd', 'category_line_even') %>">
+    <td>
+      <dl>
+        <dt> Item </dt>
+        <dd> <%= link_to invoice.item.title, item_path(invoice.item) %> </dd>
+      </dl>
+    </td>
+    <td>
+      <dt>Quantity</dt>
+      <dd><%= invoice.quantity %></dd>
+    </td>
+    <td>
+      <dt> Unit Price:</dt>
+      <dd><%= invoice.item_cost %></dd>
+    </td>
+    <td>
+      <dt> Sub-total </dt>
+      <dd> <%= invoice.quantity_cost %> </dd>
+    </td>
+  </tr>
   <% end %>
+
   Status:
   <b><%= @order.status %></b> on <%= @order.created_at.strftime("%B %d, %Y") %> at
   <%= @order.created_at.strftime("%l:%M %p") %><br />

--- a/spec/features/orders/can_view_past_orders_spec.rb
+++ b/spec/features/orders/can_view_past_orders_spec.rb
@@ -22,16 +22,17 @@ RSpec.feature "Viewing order history of illegal items" do
     click_on "Checkout"
 
     click_on "Purchase"
-    
+
     click_on "Back to all orders"
 
     # expect(current_path).to eq(order_path(@user.orders.last))
     expect(page).to have_content("View Cart")
     expect(page).to_not have_content("View Cart (4)")
+    expect(page).to have_content("total cost: $1,800.00")
+    expect(page).to have_content("Order 1")
 
-
-    expect(page).to have_content(@item1.title)
-    expect(page).to have_content(@item2.title)
+    click_on "Order 1"
     expect(page).to have_content(@item3.title)
+    expect(page).to have_content(@item1.title)
   end
 end

--- a/spec/features/users/can_log_in_spec.rb
+++ b/spec/features/users/can_log_in_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe User do
 
   it "can log in and out with right credentials" do
     visit '/login'
-
     expect(page).to have_content("Create Account")
     fill_in "Email", with: "seth@seth"
     fill_in "Password", with: "banana1"
 
+    save_and_open_page
     click_on "Sign In"
 
     expect(current_path).to eq(dashboard_path)

--- a/spec/features/users/can_log_in_spec.rb
+++ b/spec/features/users/can_log_in_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe User do
     fill_in "Email", with: "seth@seth"
     fill_in "Password", with: "banana1"
 
-    save_and_open_page
     click_on "Sign In"
 
     expect(current_path).to eq(dashboard_path)

--- a/spec/features/visitors/visitor_can_add_items_to_cart_spec.rb
+++ b/spec/features/visitors/visitor_can_add_items_to_cart_spec.rb
@@ -11,6 +11,6 @@ RSpec.feature "Visitor can add items to the cart" do
 
     expect(page).to have_current_path(cart_path)
     expect(page).to have_content(item.title)
-    expect(page).to have_content("Total: #{item.format_price}")
+    expect(page).to have_content("Total Cost: #{item.format_price}")
   end
 end


### PR DESCRIPTION
modified cart redirect:

```ruby
def create
    item = Item.find(params[:item_id])

    @cart.add_item(item.id)
    session[:cart] = @cart.contents

    flash[:notice] = "You now have #{pluralize(@cart.count_of(item.id), item.title)}."
    redirect_to :back # this is the good stuff
  end
```

tests still good.

Also, tests are cool. Allows lots of experiment without worrying that I broke stuff!